### PR TITLE
add image resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/orbiting/poc-pdf#readme",
   "dependencies": {
-    "@react-pdf/core": "^0.7.1",
+    "@react-pdf/core": "^0.7.6",
     "apollo-fetch": "^0.7.0",
     "babel-preset-stage-0": "^6.24.1",
     "d3-array": "^1.2.1",

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import { Image, StyleSheet } from '@react-pdf/core'
 
+import {
+  imageResizeUrl
+} from 'mdast-react-render/lib/utils'
+
 const styles = StyleSheet.create({
   image: {
     backgroundColor: 'grey',
@@ -11,5 +15,5 @@ const styles = StyleSheet.create({
 })
 
 export default ({ src }) => (
-  <Image style={styles.image} src={src} />
+  <Image style={styles.image} src={imageResizeUrl(src, '2000x')} />
 )

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -54,7 +54,7 @@ const figure = {
       matchMdast: matchImageParagraph,
       component: Image,
       props: node => ({
-        src: node.children[0].url.split('?')[0], // ?size=... breaks it.
+        src: node.children[0].url,
         alt: node.children[0].alt
       }),
       isVoid: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@react-pdf/core@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@react-pdf/core/-/core-0.7.1.tgz#761a1398c76a068a960dfb69d9e064268dcbbe2e"
+"@react-pdf/core@^0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@react-pdf/core/-/core-0.7.6.tgz#06c60142bd51a02537cac8f9f29c50c784b7b4dc"
   dependencies:
     blob-stream "^0.1.3"
     fbjs "^0.8.4"
@@ -67,11 +67,12 @@
     lodash.pick "^4.4.0"
     lodash.topairsin "^4.3.0"
     lodash.upperfirst "^4.3.1"
+    media-engine "^1.0.3"
     pdfkit "0.8.1"
     png-js "0.1.1"
     react-reconciler "^0.7.0"
     request "^2.81.0"
-    yoga-layout "1.6.0"
+    yoga-layout "1.9.3"
 
 "@types/zen-observable@0.5.3":
   version "0.5.3"
@@ -3529,6 +3530,10 @@ mdast-react-render@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mdast-react-render/-/mdast-react-render-1.2.0.tgz#7c6cf66d88ef4dcfe9c0edabafafaaad9b57a6b3"
 
+media-engine@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/media-engine/-/media-engine-1.0.3.tgz#be3188f6cd243ea2a40804a35de5a5b032f58dad"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -3634,9 +3639,13 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0, nan@^2.7.0:
+nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
+nan@^2.9.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nanomatch@^1.2.5:
   version "1.2.7"
@@ -3658,13 +3667,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nbind@^0.3.8:
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/nbind/-/nbind-0.3.14.tgz#ea85b685ae86801012509062f6ce4d639a19b864"
+nbind@^0.3.14:
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/nbind/-/nbind-0.3.15.tgz#20c74d77d54e28627ab8268c2767f7e40aef8c53"
   dependencies:
     emscripten-library-decorator "~0.2.2"
     mkdirp "~0.5.1"
-    nan "^2.7.0"
+    nan "^2.9.2"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -3677,7 +3686,7 @@ node-fetch@1.7.3, node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-gyp@^3.4.0:
+node-gyp@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
   dependencies:
@@ -5293,13 +5302,13 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yoga-layout@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/yoga-layout/-/yoga-layout-1.6.0.tgz#82046dab9b4940ad2868f0d795bf7e3517e96382"
+yoga-layout@1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/yoga-layout/-/yoga-layout-1.9.3.tgz#f851935187f6d2945639b79c57ee0eac2fb7d886"
   dependencies:
     autogypi "^0.2.2"
-    nbind "^0.3.8"
-    node-gyp "^3.4.0"
+    nbind "^0.3.14"
+    node-gyp "^3.6.2"
 
 zen-observable@^0.7.0:
   version "0.7.1"


### PR DESCRIPTION
Works since https://github.com/diegomura/react-pdf/pull/207

`'mdast-react-render/lib/utils'` also provides a `imageSizeInfo` to get size information from our image urls. All of our image urls contain size information in the query string: `?size=WxH`. Full list of utils with function signature: [mdast-react-render#utils](https://github.com/orbiting/mdast/tree/master/packages/mdast-react-render#utils).