### PR TITLE
Disable orphans on headings

### DIFF
--- a/src/components/H1.js
+++ b/src/components/H1.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
 })
 
 const H1 = ({ children }) => (
-  <Text style={styles.headline}>{children}</Text>
+  <Text style={styles.headline} orphan={false}>{children}</Text>
 )
 
 export default H1

--- a/src/components/H2.js
+++ b/src/components/H2.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
 })
 
 const H2 = ({ children }) => (
-  <Text style={styles.subheadline}>{children}</Text>
+  <Text style={styles.subheadline} orphan={false}>{children}</Text>
 )
 
 export default H2

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -4,7 +4,6 @@ import { fontFamilies } from '../lib/fonts'
 
 const styles = StyleSheet.create({
   text: {
-    width: 500,
     fontSize: 14,
     marginBottom: 10,
     lineHeight: 2, // not supported.


### PR DESCRIPTION
@tpreusse what do you think about this API? now you can disable orphans for any page children element. You can observe the results here: https://github.com/orbiting/poc-pdf/issues/26

Fixes #26 